### PR TITLE
Add rtl support -- basically only effects 'phasorangle'

### DIFF
--- a/menclose/index.html
+++ b/menclose/index.html
@@ -938,6 +938,81 @@
       </math>
     </li>
   </ol>
+
+  <h2>menclose rtl dir tests</h2>
+  <p>'dir' is set on 'math' element unless otherwise specified.</p>
+  <ol>
+    <li>menclose phasorangle (should reverse):
+      <math xmlns="http://www.w3.org/1998/Math/MathML" display="block" dir="rtl">
+        <menclose notation="phasorangle">
+          <mrow>
+            <mi>π</mi>
+            <mo>/</mo>
+            <mn>8</mn>
+          </mrow>
+        </menclose>
+      </math>
+    </li>
+    <li>menclose phasorangle (dir set on 'mrow', should reverse):
+      <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+        <mrow  dir="rtl">
+          <menclose notation="phasorangle">
+            <mrow>
+              <mi>π</mi>
+              <mo>/</mo>
+              <mn>8</mn>
+            </mrow>
+          </menclose>
+          </mrow>
+      </math>
+        </li>
+    <li>menclose radical (should reverse, relies on underlying implementation of msqrt):
+      <math xmlns="http://www.w3.org/1998/Math/MathML" display="block" dir="rtl">
+        <menclose notation="radical">
+          <mrow>
+            <mi>π</mi>
+            <mo>/</mo>
+            <mn>8</mn>
+          </mrow>
+        </menclose>
+      </math>
+    </li>
+    <li>menclose left (should stay on left):
+      <math xmlns="http://www.w3.org/1998/Math/MathML" display="block" dir="rtl">
+        <menclose notation="left">
+          <mrow>
+            <mi>π</mi>
+            <mo>/</mo>
+            <mn>8</mn>
+          </mrow>
+        </menclose>
+      </math>
+    </li>
+    <li>menclose longdiv (should stay on left):
+      <math xmlns="http://www.w3.org/1998/Math/MathML" display="block" dir="rtl">
+        <menclose notation="longdiv">
+          <mrow>
+            <mi>π</mi>
+            <mo>/</mo>
+            <mn>8</mn>
+          </mrow>
+        </menclose>
+      </math>
+    </li>
+    <li>menclose rightarrow (should still point to right):
+      <math xmlns="http://www.w3.org/1998/Math/MathML" display="block" dir="rtl">
+        <menclose notation="rightarrow">
+          <mrow>
+            <mi>π</mi>
+            <mo>/</mo>
+            <mn>8</mn>
+          </mrow>
+        </menclose>
+      </math>
+    </li>
+
+    </ol>
+
 </body>
 
 </html>

--- a/menclose/menclose.css
+++ b/menclose/menclose.css
@@ -40,6 +40,15 @@ mrow.menclose-phasorangle {
     transform-origin: bottom left;
 }
 
+mrow.menclose-phasoranglertl {
+    display: inline-block;
+    right: 0;
+    bottom: 0;
+    position: absolute;
+    border-top: 0.067em solid;
+    transform-origin: bottom right;
+}
+
 mrow.menclose-box {
     position: absolute;
     top: 0;


### PR DESCRIPTION
Fixed small positioning bug with 'phasorangle' (lines didn't touch)
The fix has the side effect of adding support for a new notation 'phasoranglertl' which is legal according to the spec.

Added tests for rtl.