### PR TITLE
use import.meta.url to reference css

### DIFF
--- a/elem-math/elemMath.js
+++ b/elem-math/elemMath.js
@@ -977,7 +977,8 @@ function addStyleSheetToShadowRoot(shadowRoot) {
     const link = document.createElement("link");
     link.rel = 'stylesheet';
     link.type = 'text/css';
-    link.href = './elem-math/elemMath.css';
+    link.href = import.meta.url + '/../elemMath.css';
+//    link.href = './elemMath.css';
     style.appendChild(link);
     shadowRoot.appendChild(style); 
 }


### PR DESCRIPTION
Generate an absolute URL  in the inserted `<link href`  so the css is located relative to the Javascript, not to the document containing the mathml. May not be the best way, but enough to enable rendering in the MathML4 draft.

