### PR TITLE
Fix misplaced paren in accent.js

### DIFF
--- a/accent/accent.js
+++ b/accent/accent.js
@@ -103,7 +103,7 @@ function setAccentValue(child,attrName) {
 const transformAccents = (el) => {
   // If the 2nd/3rd args are <mo> or if they have accent=true,
   // add 'accent'/'accentunder' = true to 'el' (mover, etc)
-  if (!el.getAttribute("accentunder" && el.tagName !== 'mover')) {
+  if (!el.getAttribute("accentunder") && el.tagName !== 'mover') {
     // if accentunder is not set on munder/munderover, check to see if we should set it
     setAccentValue(el.children[1], 'accentunder');
   }

--- a/acid-test.html
+++ b/acid-test.html
@@ -144,7 +144,7 @@
             </td>
             <td>
                 <math xmlns="http://www.w3.org/1998/Math/MathML">
-                    <munder align="left" accent="true">
+                    <munder align="left" accentunder="true">
                         <mrow>
                             <mi>r</mi>
                             <mo>+</mo>
@@ -164,7 +164,7 @@
                         <mo accent="true">&#x25B3;</mo>
                     </munder>
                     <mo>,</mo>
-                    <munder align="right" accent="true">
+                    <munder align="right" accentunder="true">
                         <mrow>
                             <mi>r</mi>
                             <mo>+</mo>
@@ -224,7 +224,7 @@
             </td>
             <td>
                 <math xmlns="http://www.w3.org/1998/Math/MathML">
-                    <munderover align="left" accent="true">
+                    <munderover align="left" accentunder="true" accent="true">
                         <mrow>
                             <mi>r</mi>
                             <mo>+</mo>
@@ -246,7 +246,7 @@
                         <mo accent="true">&#x25B3;</mo>
                     </munderover>
                     <mo>,</mo>
-                    <munderover align="right" accent="true">
+                    <munderover align="right" accentunder="true" accent="true">
                         <mrow>
                             <mi>r</mi>
                             <mo>+</mo>


### PR DESCRIPTION
This fixes putting `accentunder` on `mover`.